### PR TITLE
Préciser que COGugaison est sur GitHub

### DIFF
--- a/CARTElette/DESCRIPTION
+++ b/CARTElette/DESCRIPTION
@@ -30,3 +30,4 @@ Imports:
     graphics,
     grid
 VignetteBuilder: knitr
+Remotes: antuki/COGugaison


### PR DESCRIPTION
Salut Kim,

J'ai essayé d'installer CARTElette sur une configuration qui n'avait pas COGugaison d'installé.
L'installation plante car R cherche le package COGugaison sur le CRAN.

On peut résoudre le problème en rajoutant le champ `Remotes:` dans le fichier DESCRIPTION.

Évidemment, il faudra retirer ce champ quand COGugaison sera disponible sur le CRAN.